### PR TITLE
Bump node.js version to 6.11.1 due to security vulnerability

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
   environment:
     CI: true
   node:
-    version: 5.11.0
+    version: 6.11.1
 
 checkout:
   post:


### PR DESCRIPTION
See:
https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/